### PR TITLE
Incremental select query for Presto

### DIFF
--- a/dbsa/presto.py
+++ b/dbsa/presto.py
@@ -167,7 +167,7 @@ class Table(BaseDialect):
             suffix=suffix,
         )
 
-    def get_incremental_update_select(self, update_select, row_identifier, condition='', ignored_partitions=None, params=None, transforms=None):
+    def get_incremental_update_select(self, update_select, row_identifier=None, condition='', ignored_partitions=None, params=None, transforms=None):
         return Template("""
             WITH incremental_update AS (
                 {{ update_select }}
@@ -180,10 +180,12 @@ class Table(BaseDialect):
             UNION ALL
             SELECT * 
             FROM recent_data
+            {%- if row_identifier %}
             WHERE {{ row_identifier }} NOT IN (
                 SELECT {{ row_identifier }}
                 FROM incremental_update
             )
+            {%- endif %}
         """).render(
             select=self.get_select_current_partition(condition=condition, ignored_partitions=ignored_partitions, params=params, transforms=transforms),
             update_select=update_select,

--- a/dbsa/presto.py
+++ b/dbsa/presto.py
@@ -167,7 +167,7 @@ class Table(BaseDialect):
             suffix=suffix,
         )
 
-    def get_incremental_update_select(self, update_select, row_identifier=None, condition='', ignored_partitions=None, params=None, transforms=None):
+    def get_incremental_update_select(self, update_select, row_identifier=None, filter_fn=None, condition='', ignored_partitions=None, params=None, transforms=None):
         return Template("""
             WITH incremental_update AS (
                 {{ update_select }}
@@ -187,7 +187,12 @@ class Table(BaseDialect):
             )
             {%- endif %}
         """).render(
-            select=self.get_select_current_partition(condition=condition, ignored_partitions=ignored_partitions, params=params, transforms=transforms),
+            select=self.get_select_current_partition(
+                condition=condition,
+                ignored_partitions=ignored_partitions,
+                params=params,
+                transforms=transforms,
+                filter_fn=filter_fn or lambda x: x.name not in map(lambda y: y.name, self.partitions)),
             update_select=update_select,
-            row_identifier=row_identifier
+            row_identifier=row_identifier,
         )

--- a/dbsa/presto.py
+++ b/dbsa/presto.py
@@ -192,7 +192,7 @@ class Table(BaseDialect):
                 ignored_partitions=ignored_partitions,
                 params=params,
                 transforms=transforms,
-                filter_fn=filter_fn or lambda x: x.name not in map(lambda y: y.name, self.partitions)),
+                filter_fn=filter_fn or (lambda x: x.name not in map(lambda y: y.name, self.partitions)),
             update_select=update_select,
             row_identifier=row_identifier,
         )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-version = '0.0.39'
+version = '0.0.40'
 
 setup(
     name='dbsa',


### PR DESCRIPTION
Feature to be able to create incremental queries for a table.

Usage:
```python
import dbsa
from dbsa import hive, presto

class TestTable(dbsa.Table):
    _preferred_dialect = presto
    _format = dbsa.Format(format='ORC')
    ds = dbsa.Partition(dbsa.Varchar())
    id = dbsa.Bigint()
    field = dbsa.Varchar()

a = presto.Table(TestTable(schema='data', ds="'2023-07-04'"))
print(a.get_upsert_select(
    update_select="SELECT id, field FROM other_test_table WHERE ds = '2023-07-05'",
    row_identifier='id')
)
```

Output:
```
            WITH incremental_update AS (
                SELECT 
                  id,
                  field
                FROM other_test_table 
                WHERE ds = '2023-07-05'
            )
            SELECT
              "id",
              "field"
            FROM incremental_update
            UNION ALL
            SELECT
              "id",
              "field"
            FROM (
                SELECT
                  "id",
                  "field"
                FROM "data"."test_table"
                WHERE "ds" = '2023-07-04'
            ) AS d
            WHERE NOT EXISTS (
                SELECT 1
                FROM incremental_update AS u
                WHERE u.id = d.id
            )

```