### PR TITLE
Extend presto view template with security invoker option

### DIFF
--- a/dbsa/presto.py
+++ b/dbsa/presto.py
@@ -157,12 +157,13 @@ class Table(BaseDialect):
             DROP VIEW IF EXISTS {{ t.full_table_name(quoted=True, with_prefix=True, suffix=suffix) }}
         """).render(t=self.table, suffix=suffix)
 
-    def get_create_current_partition_view(self, suffix='_latest', condition='', ignored_partitions=None, params=None, transforms=None):
+    def get_create_current_partition_view(self, suffix='_latest', condition='', ignored_partitions=None, params=None, transforms=None, security_invoker=False):
         return Template("""
-            CREATE OR REPLACE VIEW {{ t.full_table_name(quoted=True, with_prefix=True, suffix=suffix) }} AS
+            CREATE OR REPLACE VIEW {{ t.full_table_name(quoted=True, with_prefix=True, suffix=suffix) }}{%- if security_invoker %} SECURITY INVOKER{%- endif %} AS
             {{ select }}
         """).render(
             t=self.table,
             select=self.get_select_current_partition(condition=condition, ignored_partitions=ignored_partitions, params=params, transforms=transforms),
             suffix=suffix,
+            security_invoker=security_invoker
         )


### PR DESCRIPTION
The create view functionality is extended with the security invoker option as per trino documentation: https://trino.io/docs/current/sql/create-view.html

The default option is `SECURITY DEFINER`. The security invoker allows to use the security definition based on the underlying query.