### PR TITLE
Bugfix: Restricted column name

### DIFF
--- a/dbsa/__init__.py
+++ b/dbsa/__init__.py
@@ -423,8 +423,11 @@ class Table(object):
     def table_name_with_prefix(self):
         return self.table_prefix + self.table_name
 
+    def get_properties(self):
+        return self._props
+
     def get_property_by_type(self, type):
-        for p in self.properties:
+        for p in self.get_properties():
             if isinstance(p, type):
                 return p
 

--- a/dbsa/hive.py
+++ b/dbsa/hive.py
@@ -81,7 +81,7 @@ class Table(BaseDialect):
             {%- if tblformat %}
             {{ tblformat }}
             {%- endif %}
-            {%- for property in t.properties %}
+            {%- for property in t.get_properties() %}
             {{ property }}{% if not loop.last %},{% endif %}
             {%- endfor %}
             {%- if external_table and hdfs_path %}

--- a/dbsa/presto.py
+++ b/dbsa/presto.py
@@ -86,16 +86,16 @@ class Table(BaseDialect):
             {%- if inspect.getdoc(t) %}
             COMMENT '{{ inspect.getdoc(t)|replace("'", "''")|trim }}'
             {%- endif %}
-            {%- if t.properties or t.partitions %}
+            {%- if t.get_properties() or t.partitions %}
             WITH (
               {%- if t.partitions %}
               partitioned_by = ARRAY[
                 {%- for partition in t.partitions %}
                 '{{ partition.name }}'{% if not loop.last %},{% endif %}
                 {%- endfor %}
-              ]{% if t.properties %},{% endif %}
+              ]{% if t.get_properties() %},{% endif %}
               {%- endif %}
-              {%- for property in t.properties %}
+              {%- for property in t.get_properties() %}
               {{ property }}{% if not loop.last %},{% endif %}
               {%- endfor %}
             )

--- a/dbsa/redshift.py
+++ b/dbsa/redshift.py
@@ -82,7 +82,7 @@ class Table(BaseDialect):
               {{ column.quoted_name }} {{ column.column_type }}{% if column.default_value %} DEFAULT {{ column.default_value }}{% endif %}{% if column.encode %} ENCODE {{ column.encode|upper }}{% endif %}{% if not loop.last %},{% endif %}
               {%- endfor %}
             )
-            {%- for property in t.properties %}
+            {%- for property in t.get_properties() %}
             {{ property }}
             {%- endfor %};
         """).render(t=self.table, filter_fn=filter_fn, suffix=suffix)
@@ -90,7 +90,7 @@ class Table(BaseDialect):
     def get_create_table_as(self, select, embed_select=True, filter_fn=None, suffix=''):
         return Template("""
             CREATE TABLE IF NOT EXISTS {{ t.full_table_name(quoted=True, with_prefix=True, suffix=suffix) }}
-            {%- for property in t.properties %}
+            {%- for property in t.get_properties() %}
             {{ property }}
             {%- endfor %} AS
             SELECT
@@ -311,7 +311,7 @@ class Table(BaseDialect):
     def get_create_materialized_view_via_select(self, select, filter_fn=None, embed_select=True, suffix=''):
         return Template("""
             CREATE MATERIALIZED VIEW {{ t.full_table_name(quoted=True, with_prefix=True, suffix=suffix) }}
-            {%- for property in t.properties %}
+            {%- for property in t.get_properties() %}
             {{ property }}
             {%- endfor %} AS
             SELECT

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-version = '0.0.42'
+version = '0.0.43'
 
 setup(
     name='dbsa',


### PR DESCRIPTION
The `properties` column name in the schema breaks the package:

```python

>>> import dbsa
>>> from dbsa import hive, presto
>>> 
>>> class TestTable(dbsa.Table):
...     _preferred_dialect = hive
...     _format = dbsa.Format(format='AVRO')
...     date = dbsa.Partition(dbsa.Varchar())
...     id = dbsa.Varchar()
...     properties = dbsa.Varchar()
... 
>>> table = hive.Table(TestTable(schema='raw', date=None))
>>> table.get_create_table(external_table=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/dbsa/hive.py", line 93, in get_create_table
    """).render(t=self.table, filter_fn=filter_fn, external_table=external_table, hdfs_path=hdfs_path, tblformat=tblformat, tblproperties=tblproperties, inspect=inspect, suffix=suffix)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.11/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 20, in top-level template code
  File "/usr/local/lib/python3.11/site-packages/jinja2/runtime.py", line 417, in __init__
    self._iterator = self._to_iterator(iterable)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/jinja2/runtime.py", line 425, in _to_iterator
    return iter(iterable)
           ^^^^^^^^^^^^^^
TypeError: 'Varchar' object is not iterable
```