### PR TITLE
Add get_add_current_partition for trino

### DIFF
--- a/dbsa/trino.py
+++ b/dbsa/trino.py
@@ -3,6 +3,8 @@ from .presto import Table as BaseTable
 from jinja2 import Template
 import inspect
 import datetime
+import numbers
+import decimal
 
 class ExternalTableProperties(BaseExternalTableProperties):
     def get_properies(self):
@@ -72,7 +74,7 @@ class Table(BaseTable):
         return f'[{partition_list}], [{partition_values}]'
 
     def _param_to_quoted_sting(self, param):
-        if isinstance(param, int):
+        if isinstance(param, (int, float, numbers.Number, decimal.Decimal)):
             return self._how_to_quote_string.format(str(param))
         if isinstance(param, (datetime.date, datetime.datetime)):
             return self._how_to_quote_string.format(param.isoformat())

--- a/dbsa/trino.py
+++ b/dbsa/trino.py
@@ -2,6 +2,7 @@ from . import ExternalTableProperties as BaseExternalTableProperties
 from .presto import Table as BaseTable
 from jinja2 import Template
 import inspect
+import datetime
 
 class ExternalTableProperties(BaseExternalTableProperties):
     def get_properies(self):
@@ -16,6 +17,8 @@ class ExternalTableProperties(BaseExternalTableProperties):
 
 
 class Table(BaseTable):
+    _how_to_quote_string = "'{}'"
+
     def get_create_table_properties(self, external_table_properties=None):
         create_table_properties = []
 
@@ -41,7 +44,6 @@ class Table(BaseTable):
 
         return create_table_properties
 
-
     def get_create_table(self, filter_fn=None, suffix='', external_table_properties=None):
         return Template("""
             CREATE TABLE IF NOT EXISTS {{ t.full_table_name(quoted=True, with_prefix=True, suffix=suffix) }} (
@@ -60,3 +62,43 @@ class Table(BaseTable):
             )
             {%- endif %}
         """).render(t=self.table, d=self, filter_fn=filter_fn, inspect=inspect, suffix=suffix, tbl_properties=self.get_create_table_properties(external_table_properties))
+
+    def get_current_partition_list(self, ignored_partitions=None):
+        partition_names = {p.name for p in self.partitions} - set(ignored_partitions or [])
+        partitions = [p for p in self.partitions if p.name in partition_names]
+        partition_list = ', '.join([f"'{p.name}'" for p in partitions])
+        partition_values = ', '.join([f"{{{p.name}}}" for p in partitions])
+
+        return f'[{partition_list}], [{partition_values}]'
+
+    def _param_to_quoted_sting(self, param):
+        if isinstance(param, int):
+            return self._how_to_quote_string.format(str(param))
+        if isinstance(param, (datetime.date, datetime.datetime)):
+            return self._how_to_quote_string.format(param.isoformat())
+        return param
+
+    def get_add_current_partition(self, hdfs_path=None, condition='', params=None, ignored_partitions=None, suffix=''):
+        current_partition_params = {k: self._param_to_quoted_sting(v) for k, v in self.table.get_current_partition_params(params).items()}
+
+        return Template("""
+            CALL system.{% if hdfs_path %}register_partition{% else %}create_empty_partition{% endif %}('{{ t.schema }}', '{{ t.table_name_with_prefix }}', {{ condition }}{% if hdfs_path %}, '{{ hdfs_path }}'{% endif %})
+        """).render(
+            t=self.table,
+            suffix=suffix,
+            hdfs_path=hdfs_path,
+            condition=self.get_current_partition_list(ignored_partitions) \
+                .format(**current_partition_params)
+        )
+
+    def get_delete_current_partition(self, condition='', params=None, ignored_partitions=None, suffix=''):
+        current_partition_params = {k: self._to(v) for k, v in self.table.get_current_partition_params(params).items()}
+
+        return Template("""
+            CALL system.unregister_partition('{{ t.schema }}', '{{ t.table_name_with_prefix }}', {{ condition }})
+        """).render(
+            t=self.table,
+            suffix=suffix,
+            condition=self.get_current_partition_list(ignored_partitions) \
+                .format(**current_partition_params)
+        )


### PR DESCRIPTION
Example:
```python
import dbsa
from dbsa import trino

class Postcodes(dbsa.Table):
    _preferred_dialect = trino
    _format = dbsa.Format(format='ORC')
    ds = dbsa.Partition(dbsa.Varchar(), comment="Date of the download of the database")
    hour = dbsa.Partition(dbsa.Bigint(), comment="Hour")
    postcode = dbsa.Varchar(comment='Actual postcode')
    latitude = dbsa.Decimal(precision=10, scale=8, comment='Latitude of the postcode')
    longitude = dbsa.Decimal(precision=11, scale=8, comment='Longitude of the postcode')
    is_in_use = dbsa.Boolean(comment='Flag if the postcode is in use')

postcodes_tbl = trino.Table(Postcodes(schema='data', ds="'2023-01-06'", hour=11))

print(postcodes_tbl.get_add_current_partition(hdfs_path='s3://datalake/location/2024-01-01'))
```

Output:
```sql
CALL system.register_partition('data', 'postcodes', ['ds', 'hour'], ['2023-01-06', '11'], 's3://datalake/location/2024-01-01')
```

Relevant documentation: https://trino.io/docs/current/connector/hive.html#procedures

Please note that all partition parameters has to be string quoted in the list. No matter if it's stored as integer. The procedure handles the conversion, but it does not accept ARRAY elements with different types. 