### PR TITLE
feat: presto/trino timestamp length option

### DIFF
--- a/dbsa/presto.py
+++ b/dbsa/presto.py
@@ -41,7 +41,7 @@ class Table(BaseDialect):
         JSON: 'JSON',
         Date: 'DATE',
         Time: 'TIME',
-        Timestamp: 'TIMESTAMP',
+        Timestamp: 'TIMESTAMP{% if attrs.length %}({{ attrs.length }}){% endif %}',
         Array: 'ARRAY({{ data_type.column_type }})',
         Map: 'MAP({{ primitive_type.column_type }}, {{ data_type.column_type }})',
         Row: "ROW({% for c in columns %}{{ c.quoted_name }} {{ c.column_type }}{% if not loop.last %}, {% endif%}{% endfor %})",

--- a/dbsa/presto.py
+++ b/dbsa/presto.py
@@ -41,7 +41,7 @@ class Table(BaseDialect):
         JSON: 'JSON',
         Date: 'DATE',
         Time: 'TIME',
-        Timestamp: 'TIMESTAMP{% if attrs.length %}({{ attrs.length }}){% endif %}',
+        Timestamp: 'TIMESTAMP{% if attrs.length %}({{ attrs.length }}){% endif %}{% if attrs.with_timezone %} WITH TIME ZONE{% endif %}',
         Array: 'ARRAY({{ data_type.column_type }})',
         Map: 'MAP({{ primitive_type.column_type }}, {{ data_type.column_type }})',
         Row: "ROW({% for c in columns %}{{ c.quoted_name }} {{ c.column_type }}{% if not loop.last %}, {% endif%}{% endfor %})",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-version = '0.0.48'
+version = '0.0.49'
 
 setup(
     name='dbsa',
@@ -20,5 +20,5 @@ setup(
         ],
     },
     test_suite="dbsa.tests",
-    url='https://github.com/bfaludi/dbsa',
+    url='https://github.com/dataleio/dbsa',
 )


### PR DESCRIPTION
Extending Trino functionality to support timestamp length and timestamp with timezone types:
https://trino.io/docs/current/language/types.html#timestamp-p

Test run:
```python
import dbsa
from dbsa import trino

class Postcodes(dbsa.Table):
    _preferred_dialect = trino
    _format = dbsa.Format(format='ORC')
    ds = dbsa.Partition(dbsa.Varchar(), comment="Date of the download of the database")
    postcode = dbsa.Varchar(comment='Actual postcode')
    created_at = dbsa.Timestamp()
    created_at_with_length = dbsa.Timestamp(length=6)
    created_at_with_timezone = dbsa.Timestamp(with_timezone=True)
    created_at_with_length_and_timezone = dbsa.Timestamp(length=3, with_timezone=True)

postcodes_tbl = trino.Table(Postcodes(schema='data', ds="'2023-01-06'"))
print(postcodes_tbl.get_create_table())
```

Output:
```sql
            CREATE TABLE IF NOT EXISTS "data"."postcodes" (
              "postcode" VARCHAR COMMENT 'Actual postcode',
              "created_at" TIMESTAMP,
              "created_at_with_length" TIMESTAMP(6),
              "created_at_with_timezone" TIMESTAMP WITH TIME ZONE,
              "created_at_with_length_and_timezone" TIMESTAMP(3) WITH TIME ZONE,
              "ds" VARCHAR COMMENT 'Date of the download of the database'
            )
            WITH (
              partitioned_by = ARRAY[
                'ds'
              ],
              
              format = 'ORC'
            )
```