### PR TITLE
feat: add catalog as an optional table property + trino iceberg readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Database schemas for Airflow. One of the biggest issue with [Apache Airflow](https://airflow.apache.org/index.html) that it does not provide any good way to describe the database schemas within the system. It leads incorrect table definitions, hard to extend schemas and keep backwards compatibility of already existing pipelines.
 
-This package was written in mind to **use as the abstraction layer of table schemas**, and it provides support for [Presto](http://prestodb.github.io/), [Apache Hive](https://hive.apache.org/), and [Amazon Redshift](https://aws.amazon.com/redshift/).
+This package was written in mind to **use as the abstraction layer of table schemas**, and it provides support for [Presto](http://prestodb.github.io/), [Trino](https://trino.io/), [Apache Hive](https://hive.apache.org/), and [Amazon Redshift](https://aws.amazon.com/redshift/). Additionally, it includes specialized support for [Trino Iceberg](https://trino.io/docs/current/connector/iceberg.html) tables.
 
 ## Installation
 
@@ -16,40 +16,40 @@ $ pip install dbsa
 
 The following column types are supported:
 
-| Date type        | Presto support | Hive support   | Redshift support |
-| ---------------- | -------------- | -------------- | ---------------- |
-| `dbsa.Boolean`   | ✓              | ✓              | ✓                |
-| `dbsa.Tinyint`   | ✓              | ✓              | ✓                |
-| `dbsa.Smallint`  | ✓              | ✓              | ✓                |
-| `dbsa.Integer`   | ✓              | ✓              | ✓                |
-| `dbsa.Bigint`    | ✓              | ✓              | ✓                |
-| `dbsa.Real`      | ✓              | ✓              | ✓                |
-| `dbsa.Double`    | ✓              | ✓              | ✓                |
-| `dbsa.Decimal`   | ✓              | ✓              | ✓                |
-| `dbsa.Varchar`   | ✓              | ✓              | ✓                |
-| `dbsa.Char`      | ✓              | ✓              | ✓                |
-| `dbsa.Varbinary` | ✓              | ✓              |                  |
-| `dbsa.JSON`      | ✓              | ✓ AS `Varchar` |                  |
-| `dbsa.Date`      | ✓              | ✓              | ✓                |
-| `dbsa.Time`      | ✓              |                |                  |
-| `dbsa.Timestamp` | ✓              | ✓              | ✓                |
-| `dbsa.Array`     | ✓              | ✓              |                  |
-| `dbsa.Map`       | ✓              | ✓              |                  |
-| `dbsa.Row`       | ✓              | ✓              |                  |
-| `dbsa.IPAddress` | ✓              | ✓ AS `Varchar` |                  |
+| Date type        | Presto support | Trino support | Trino Iceberg support | Hive support   | Redshift support |
+| ---------------- | -------------- | ------------- | --------------------- | -------------- | ---------------- |
+| `dbsa.Boolean`   | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Tinyint`   | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Smallint`  | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Integer`   | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Bigint`    | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Real`      | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Double`    | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Decimal`   | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Varchar`   | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Char`      | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Varbinary` | ✓              | ✓             | ✓                     | ✓              |                  |
+| `dbsa.JSON`      | ✓              | ✓             | ✓                     | ✓ AS `Varchar` |                  |
+| `dbsa.Date`      | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Time`      | ✓              | ✓             | ✓                     |                |                  |
+| `dbsa.Timestamp` | ✓              | ✓             | ✓                     | ✓              | ✓                |
+| `dbsa.Array`     | ✓              | ✓             | ✓                     | ✓              |                  |
+| `dbsa.Map`       | ✓              | ✓             | ✓                     | ✓              |                  |
+| `dbsa.Row`       | ✓              | ✓             | ✓                     | ✓              |                  |
+| `dbsa.IPAddress` | ✓              | ✓             | ✓                     | ✓ AS `Varchar` |                  |
 
 
 ## Supported Table Properties
 
 The following table properties are supported:
 
-| Date type                | Presto support | Hive support | Redshift support |
-| ------------------------ | -------------- | ------------ | ---------------- |
-| `dbsa.Format`            | ✓              | ✓            |                  |
-| `dbsa.Bucket`            | ✓              | ✓            |                  |
-| `dbsa.Sortkey`           |                |              | ✓                |
-| `dbsa.DistributionKey`   |                |              | ✓                |
-| `dbsa.DistributionStyle` |                |              | ✓                |
+| Date type                | Presto support | Trino support | Trino Iceberg support | Hive support | Redshift support |
+| ------------------------ | -------------- | ------------- | --------------------- | ------------ | ---------------- |
+| `dbsa.Format`            | ✓              | ✓             | ✓                     | ✓            |                  |
+| `dbsa.Bucket`            | ✓              | ✓             | ✓                     | ✓            |                  |
+| `dbsa.Sortkey`           |                |               |                       |              | ✓                |
+| `dbsa.DistributionKey`   |                |               |                       |              | ✓                |
+| `dbsa.DistributionStyle` |                |               |                       |              | ✓                |
 
 ## PII data types for column classification
 
@@ -95,10 +95,12 @@ class Metrics(dbsa.Table):
 This table definition is not binded to any dialect yet. To use the table, you must bind it to one. When creating the table instances, we must specify the name of the `schema`, and fill the missing partitions. `dbsa` will not quote your data since you can use functions, UDFs, so please put quotes around your data if it's needed.
 
 ```python
-from dbsa import presto, hive
+from dbsa import presto, hive, trino, trino_iceberg
 
 presto_tbl = presto.Table(Metrics(schema='default', ds="'2019-07-27'"))
 hive_tbl = hive.Table(Metrics(schema='default', ds="'2019-07-27'"))
+trino_tbl = trino.Table(Metrics(schema='default', ds="'2019-07-27'"))
+trino_iceberg_tbl = trino_iceberg.Table(Metrics(schema='default', ds="'2019-07-27'"))
 ```
 
 After that, we can start generating SQL queries based on the dialect.
@@ -114,6 +116,36 @@ print(hive_tbl.get_delete_current_partition(ignored_partitions=['aggregation']))
 # ) PURGE
 ```
 As you can see, the dialects are working quite easily, and we can even specify that ignore our `aggregation` subpartition.
+
+## Trino and Trino Iceberg Support
+
+The package now includes support for both **Trino** and **Trino Iceberg** dialects:
+
+- **`dbsa.trino`**: Standard Trino (on Hive) support with `partitioned_by` and `external_location` properties
+- **`dbsa.trino_iceberg`**: Specialized support for Iceberg tables using `partitioning` and `location` properties
+
+### Trino Iceberg Features
+
+Trino Iceberg support includes:
+
+- **Custom partitions**: Add additional partitions beyond the table's defined partitions
+- **Iceberg-specific properties**: Uses `location` instead of `external_location` and `partitioning` instead of `partitioned_by`
+
+```python
+from dbsa import trino_iceberg
+
+# Create Iceberg table with additional custom partitions
+iceberg_tbl = trino_iceberg.Table(
+    Metrics(schema='default', ds="'2019-07-27'"),
+    custom_partitions=['region', 'category']
+)
+
+# External table properties for Iceberg
+iceberg_props = trino_iceberg.ExternalTableProperties(
+    location='s3://my-bucket/data/',
+    configs={'table_type': 'ICEBERG'}
+)
+```
 
 ```python
 print(presto_tbl.get_create_table())
@@ -157,5 +189,5 @@ class IncomingEvents(dbsa.Table):
 You must pick a dialect, and just run the following command.
 
 ```bash
-dbsa-markdown {prest|hive|redshift} file.py
+dbsa-markdown {presto|trino|trino_iceberg|hive|redshift} file.py
 ```

--- a/dbsa/__init__.py
+++ b/dbsa/__init__.py
@@ -47,7 +47,7 @@ Cleanup function for staging tables
 """
 
 def cleanup_fn(value, quoted, dashed):
-    rvalue = re.sub('^.*\((.*?)\)$', '\\1', str(value))
+    rvalue = re.sub(r'^.*\((.*?)\)$', r'\1', str(value))
     if not quoted:
         rvalue = rvalue.replace("'", '')
     if not dashed:
@@ -401,7 +401,7 @@ class Table(object):
     _how_to_quote = '"{}"'
     _sample_value_function = 'MAX({c})'
 
-    def __init__(self, schema, dialect=None, **values):
+    def __init__(self, schema, dialect=None, catalog=None, **values):
         if not hasattr(self, '_prototype'):
             raise PrototypeRequired('Prototype declaration is required!')
 
@@ -416,6 +416,7 @@ class Table(object):
         self._policies = {p.__class__.__name__ : p for p in self._prototype.policies}
 
         self.schema = schema
+        self.catalog = catalog
         self.dialect = None
         self.register_dialect(dialect)
 
@@ -492,12 +493,20 @@ class Table(object):
     def full_table_name(self, quoted=False, with_prefix=False, suffix=''):
         table_name = self._quote((self.table_name_with_prefix if with_prefix else self.table_name) + suffix, quoted)
         schema = self._quote(self.schema, quoted)
-        return '{}.{}'.format(schema, table_name)
+        if self.catalog is not None:
+            catalog = self._quote(self.catalog, quoted)
+            return '{}.{}.{}'.format(catalog, schema, table_name)
+        else:
+            return '{}.{}'.format(schema, table_name)
 
     def full_staging_table_name(self, cleanup_fn=cleanup_fn, quoted=False, with_prefix=False, suffix=''):
         table_name = self._quote((self.staging_table_name_with_prefix(cleanup_fn=cleanup_fn) if with_prefix else self.staging_table_name(cleanup_fn=cleanup_fn)) + suffix, quoted)
         schema = self._quote(self.schema, quoted)
-        return '{}.{}'.format(schema, table_name)
+        if self.catalog is not None:
+            catalog = self._quote(self.catalog, quoted)
+            return '{}.{}.{}'.format(catalog, schema, table_name)
+        else:
+            return '{}.{}'.format(schema, table_name)
 
     def column_values(self, include_partitions=True, filter_fn=None):
         return (c.default_load_value for c in self.columns(include_partitions=include_partitions, filter_fn=filter_fn))
@@ -514,6 +523,8 @@ class Table(object):
         if condition: conditions.append(condition)
         return sep.join(conditions)
 
+    def set_catalog(self, catalog):
+        self.catalog = catalog
 
 class Dialect(object):
     _column_types = {}

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-version = '0.0.50'
+version = '0.1.0'
 
 setup(
     name='dbsa',


### PR DESCRIPTION
Example:
```python
import dbsa
from dbsa import trino_iceberg

class Postcodes(dbsa.Table):
    _preferred_dialect = trino_iceberg
    _format = dbsa.Format(format='ORC')
    ds = dbsa.Partition(dbsa.Varchar(), comment="Date of the download of the database")
    postcode = dbsa.Varchar(comment='Actual postcode')
    created_at = dbsa.Timestamp()
    created_at_with_length = dbsa.Timestamp(length=6)
    created_at_with_timezone = dbsa.Timestamp(with_timezone=True)
    created_at_with_length_and_timezone = dbsa.Timestamp(length=3, with_timezone=True)

postcodes_tbl = trino_iceberg.Table(Postcodes(catalog='iceberg', schema='data', ds="'2023-01-06'"))
print(postcodes_tbl.get_create_table())
```

```sql
            CREATE TABLE IF NOT EXISTS "iceberg"."data"."postcodes" (
              "postcode" VARCHAR COMMENT 'Actual postcode',
              "created_at" TIMESTAMP,
              "created_at_with_length" TIMESTAMP(6),
              "created_at_with_timezone" TIMESTAMP WITH TIME ZONE,
              "created_at_with_length_and_timezone" TIMESTAMP(3) WITH TIME ZONE,
              "ds" VARCHAR COMMENT 'Date of the download of the database'
            )
            WITH (
              partitioning = ARRAY[
                'ds'
              ],
              
              format = 'ORC'
            )

```